### PR TITLE
fixing broken christianh814 link in references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NOTE: Those baremetal servers are Dell based, so `racadm` will be used in order 
 
 # References
 
-* https://github.com/christianh814/openshift-toolbox/tree/master/ocp4_upi_beta
+* https://github.com/christianh814/openshift-toolbox/tree/master/ocp4_upi
 * https://docs.openshift.com/container-platform/4.1/installing/installing_bare_metal/installing-bare-metal.html
 
 # Steps


### PR DESCRIPTION
christianh814 has changed the name of his directory from ocp4_upi_beta to ocp4_upi, the actual link returns a 404 error